### PR TITLE
fix: treat barcodeTypes parameter as array

### DIFF
--- a/android/src/main/java/com/visioncameracodescanner/CodeScannerProcessorPlugin.java
+++ b/android/src/main/java/com/visioncameracodescanner/CodeScannerProcessorPlugin.java
@@ -106,12 +106,9 @@ public class CodeScannerProcessorPlugin extends FrameProcessorPlugin {
     Set<Integer> barcodeFormats = new HashSet<>();
 
     if (params != null) {
-      HashMap<String, String> barcodeTypes = (HashMap<
-          String,
-          String
-        >) params.get("barcodeTypes");
+      List<String> barcodeTypes = (ArrayList<String>) params.get("barcodeTypes");
       if (barcodeTypes != null && barcodeTypes.size() > 0) {
-        for (String type : barcodeTypes.values()) {
+        for (String type : barcodeTypes) {
           switch (type) {
             case "code-128":
               barcodeFormats.add(Barcode.FORMAT_CODE_128);

--- a/ios/CodeScannerProcessorPlugin.m
+++ b/ios/CodeScannerProcessorPlugin.m
@@ -27,10 +27,9 @@ static RCTEventEmitter* eventEmitter = nil;
   RCTLogInfo(@"Processing frame with width: %lu, height: %lu and arguments: %@", width, height, arguments);
 
   // Parse the barcode types to be detected
-  NSDictionary* barcodeTypes = arguments[@"barcodeTypes"];
+  NSArray* barcodeTypes = arguments[@"barcodeTypes"];
   NSMutableArray* symbologies = [NSMutableArray new];
-  for (NSString* key in barcodeTypes) {
-    NSString* barcodeType = [barcodeTypes objectForKey:key];
+  for (NSString* barcodeType in barcodeTypes) {
     VNBarcodeSymbology symbology = [self barcodeSymbologyFromString:barcodeType];
     if (symbology != nil) {
       [symbologies addObject:symbology];


### PR DESCRIPTION
Looks like some old code was still in place for parsing `barcodeTypes` which was expecting an object but on JS side it will always be provided as an array.

Fixes: https://github.com/mgcrea/vision-camera-barcode-scanner/issues/18