### PR TITLE
Address breaking changes in react-native-vision-camera v3.8.0

### DIFF
--- a/android/src/main/java/com/visioncameracodescanner/CodeScannerProcessorPlugin.java
+++ b/android/src/main/java/com/visioncameracodescanner/CodeScannerProcessorPlugin.java
@@ -15,6 +15,7 @@ import com.google.mlkit.vision.barcode.common.Barcode;
 import com.google.mlkit.vision.common.InputImage;
 import com.mrousavy.camera.frameprocessor.Frame;
 import com.mrousavy.camera.frameprocessor.FrameProcessorPlugin;
+import com.mrousavy.camera.frameprocessor.VisionCameraProxy;
 import com.mrousavy.camera.types.Orientation;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,8 +32,7 @@ public class CodeScannerProcessorPlugin extends FrameProcessorPlugin {
   private BarcodeScanner barcodeScanner = null;
   private int barcodeScannerFormatsBitmap = -1;
 
-  CodeScannerProcessorPlugin(@Nullable Map<String, Object> options) {
-    super(options);
+  CodeScannerProcessorPlugin(@NotNull VisionCameraProxy proxy, @Nullable Map<String, Object> options) {
     Log.d(
       VisionCameraCodeScannerModule.NAME,
       "CodeScannerProcessorPlugin initialized with options: " + options

--- a/android/src/main/java/com/visioncameracodescanner/VisionCameraCodeScannerPackage.java
+++ b/android/src/main/java/com/visioncameracodescanner/VisionCameraCodeScannerPackage.java
@@ -19,8 +19,8 @@ public class VisionCameraCodeScannerPackage implements ReactPackage {
   public VisionCameraCodeScannerPackage() {
     FrameProcessorPluginRegistry.addFrameProcessorPlugin(
       VisionCameraCodeScannerModule.NAME,
-      options -> {
-        plugin = new CodeScannerProcessorPlugin(options);
+      (proxy, options) -> {
+        plugin = new CodeScannerProcessorPlugin(proxy, options);
         return plugin;
       }
     );

--- a/ios/CodeScannerProcessorPlugin.m
+++ b/ios/CodeScannerProcessorPlugin.m
@@ -6,8 +6,9 @@ static RCTEventEmitter* eventEmitter = nil;
 
 @implementation CodeScannerProcessorPlugin
 
-- (instancetype)initWithOptions:(NSDictionary*)options {
-  self = [super init];
+- (instancetype) initWithProxy:(VisionCameraProxyHolder*)proxy
+                   withOptions:(NSDictionary* _Nullable)options {
+  self = [super initWithProxy:proxy withOptions:options];
   return self;
 }
 
@@ -231,8 +232,8 @@ static RCTEventEmitter* eventEmitter = nil;
 + (void)load {
   [FrameProcessorPluginRegistry
       addFrameProcessorPlugin:[VisionCameraCodeScanner name]
-              withInitializer:^FrameProcessorPlugin*(NSDictionary* options) {
-                return [[CodeScannerProcessorPlugin alloc]
+              withInitializer:^FrameProcessorPlugin*(VisionCameraProxyHolder* _Nonnull proxy, NSDictionary* _Nullable options) {
+                return [[CodeScannerProcessorPlugin alloc] initWithProxy:proxy withOptions:options];
                     initWithOptions:options];
               }];
 }

--- a/ios/CodeScannerProcessorPlugin.m
+++ b/ios/CodeScannerProcessorPlugin.m
@@ -234,7 +234,6 @@ static RCTEventEmitter* eventEmitter = nil;
       addFrameProcessorPlugin:[VisionCameraCodeScanner name]
               withInitializer:^FrameProcessorPlugin*(VisionCameraProxyHolder* _Nonnull proxy, NSDictionary* _Nullable options) {
                 return [[CodeScannerProcessorPlugin alloc] initWithProxy:proxy withOptions:options];
-                    initWithOptions:options];
               }];
 }
 


### PR DESCRIPTION
In react-native-vision-camera 3.8.0, Marc made some breaking changes mentioned [here](https://github.com/mrousavy/react-native-vision-camera/releases/tag/v3.8.0). This pull request addresses those breaking changes such that the plugin will build on iOS and Android now.

**Important caveat:** It has been _years_ since I've done any Java/C development, so please review this PR with a very skeptical eye and feel free to hack it up if need be! It works for me locally™.

Fixes #17.