### PR TITLE
fix: pre-compute Platform.OS for worklet serialization on RN 0.81+

### DIFF
--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -9,18 +9,22 @@ import type {
 } from "src/types";
 import { normalizeAndroidCodeType, normalizeiOSCodeType } from "./types";
 
+// Pre-compute Platform.OS at module scope so worklets only capture a primitive
+// string instead of the complex Platform object (which can't be serialized).
+const _platformOS = Platform.OS;
+
 export const isIOSBarcode = (
   barcode: iOSBarcode | AndroidBarcode,
 ): barcode is iOSBarcode => {
   "worklet";
-  return Platform.OS === "ios";
+  return _platformOS === "ios";
 };
 
 export const isAndroidBarcode = (
   barcode: iOSBarcode | AndroidBarcode,
 ): barcode is AndroidBarcode => {
   "worklet";
-  return Platform.OS === "android";
+  return _platformOS === "android";
 };
 
 export const computeBoundingBoxFromCornerPoints = (
@@ -52,6 +56,7 @@ export const normalizeNativeBarcode = (
   barcode: iOSBarcode | AndroidBarcode,
   frame: Frame,
 ): Barcode => {
+  "worklet";
   if (isIOSBarcode(barcode)) {
     const { payload, symbology, boundingBox, corners } = barcode;
     return {
@@ -83,7 +88,7 @@ export const normalizeNativeBarcode = (
       native: barcode,
     };
   } else {
-    throw new Error(`Unsupported platform: ${Platform.OS}`);
+    throw new Error(`Unsupported platform: ${_platformOS}`);
   }
 };
 

--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -52,7 +52,6 @@ export const normalizeNativeBarcode = (
   barcode: iOSBarcode | AndroidBarcode,
   frame: Frame,
 ): Barcode => {
-  "worklet";
   if (isIOSBarcode(barcode)) {
     const { payload, symbology, boundingBox, corners } = barcode;
     return {

--- a/src/utils/geometry.ts
+++ b/src/utils/geometry.ts
@@ -3,6 +3,10 @@ import type { CameraProps, Orientation } from "react-native-vision-camera";
 import type { Point, Size } from "src/types";
 import { normalizePrecision } from "./convert";
 
+// Pre-compute Platform.OS at module scope so worklets only capture a primitive
+// string instead of the complex Platform object (which can't be serialized).
+const _platformOS = Platform.OS;
+
 export const applyScaleFactor = (
   { x, y }: Point,
   source: Size,
@@ -48,7 +52,7 @@ export const applyTransformation = (
 ): Point => {
   "worklet";
 
-  if (Platform.OS === "android") {
+  if (_platformOS === "android") {
     switch (orientation) {
       case "landscape-right":
         return { x: target.height - y, y: x };
@@ -62,9 +66,9 @@ export const applyTransformation = (
         console.warn(`Unsupported orientation: ${orientation}`);
         return { x, y };
     }
-  } else if (Platform.OS === "ios") {
+  } else if (_platformOS === "ios") {
     return { x: y, y: x };
   } else {
-    throw new Error(`Unsupported platform: ${Platform.OS}`);
+    throw new Error(`Unsupported platform: ${_platformOS}`);
   }
 };


### PR DESCRIPTION
## Problem

On React Native 0.81+, opening the barcode scanner crashes with:

```
Value type not supported: VisionCameraProxy.setFrameProcessor
```

Related: https://github.com/mgcrea/vision-camera-barcode-scanner/issues/46

### Root cause

The library is bundled with `tsup`, which flattens all source modules into a single dist file. Several worklet functions (`isIOSBarcode`, `isAndroidBarcode`, `normalizeNativeBarcode`, `applyTransformation`) reference `Platform.OS` directly. When the consumer's Reanimated Babel plugin processes these worklets, it tries to serialize the `Platform` object into the worklet closure. But `Platform` is a complex React Native object that can't be serialized by the worklet runtime.

This worked on older RN versions but breaks on RN 0.81+ due to stricter worklet serialization.

## Fix

Extract `Platform.OS` into a simple string constant (`_platformOS`) at module scope, so worklet closures only capture a primitive string instead of the full `Platform` object.

The `"worklet"` directive is kept intact — functions still run on the worklet thread as intended.

### Files changed

- `src/utils/convert.ts` — `isIOSBarcode`, `isAndroidBarcode`, `normalizeNativeBarcode`
- `src/utils/geometry.ts` — `applyTransformation`

### Tested with

```
"react-native": "0.81.5"
"react-native-vision-camera": "^4.7.3"
"@mgcrea/vision-camera-barcode-scanner": "^0.12.3"
```
